### PR TITLE
Remove unnecessary `apt-get update` run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ADD mariadb.list /etc/apt/sources.list.d/
 RUN chown root: /etc/apt/sources.list.d/mariadb.list
-RUN apt-get update &&  \
-    apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db && \
+RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db && \
     apt-get update && \
     apt-get install -y mariadb-galera-server galera
 


### PR DESCRIPTION
After commit 0bfc4254 (Use separate file for package archive), removing
installation of the package software propertiers, running `apt-get
update` before adding the GPG key is not needed anymore and running it
afterward is enough. It even causes warnings so remove it.

```
[…]
Step 6 : RUN apt-get update &&      apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db &&     apt-get update &&     apt-get install -y mariadb-galera-server galera
 ---> Running in 686483e2d907
Get:1 http://mirrors.n-ix.net jessie InRelease [2488 B]
Ign http://mirrors.n-ix.net jessie InRelease
Ign http://httpredir.debian.org jessie InRelease
Get:2 http://mirrors.n-ix.net jessie/main amd64 Packages [5639 B]
Get:3 http://httpredir.debian.org jessie Release.gpg [2373 B]
Ign http://mirrors.n-ix.net jessie/main Translation-en
Get:4 http://httpredir.debian.org jessie Release [148 kB]
Get:5 http://httpredir.debian.org jessie/main amd64 Packages [6764 kB]
Get:6 http://httpredir.debian.org jessie/main Translation-en [4585 kB]
Fetched 11.5 MB in 2s (5099 kB/s)
Reading package lists...
W: GPG error: http://mirrors.n-ix.net jessie InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY CBCB082A1BB943DB
[…]
```
